### PR TITLE
:wrench: Update exports and add benchmarks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_stages: [ commit, push ]
 
 repos:
     -   repo: https://github.com/pre-commit/pre-commit-hooks
-        rev: v4.3.0
+        rev: v4.4.0
         hooks:
             -   id: check-toml
             -   id: check-yaml
@@ -17,7 +17,6 @@ repos:
             -   id: fix-byte-order-marker
             -   id: name-tests-test
                 args: [ --pytest-test-first ]
-                exclude: images/
             -   id: end-of-file-fixer
                 exclude: LICENSE
 
@@ -25,7 +24,7 @@ repos:
         hooks:
             -   id: ruff
                 name: ruff
-                entry: ruff check
+                entry: poetry run ruff check
                 types: [ python ]
                 language: system
 
@@ -33,6 +32,6 @@ repos:
         hooks:
             -   id: black
                 name: black
-                entry: black --config pyproject.toml
+                entry: poetry run black --config pyproject.toml
                 types: [ python ]
                 language: system

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,7 +19,7 @@ tasks:
         cmd: curl -sSL https://install.python-poetry.org | python - --uninstall
 
     poetry-update-dev:
-        cmd: poetry add pytest@latest pytest-html@latest hypothesis@latest coverage@latest pytest-cov@latest coverage-badge@latest ruff@latest pre-commit@latest black@latest pyright@latest typing-extensions@latest bandit@latest safety@latest numpy@latest torch@latest jax@latest -G dev
+        cmd: poetry add pytest@latest pytest-html@latest hypothesis@latest coverage@latest pytest-cov@latest pytest-benchmark@latest coverage-badge@latest ruff@latest pre-commit@latest black@latest pyright@latest typing-extensions@latest bandit@latest safety@latest numpy@latest torch@latest jax@latest -G dev
 
     pre-commit-install:
         cmd: poetry run pre-commit install

--- a/poetry.lock
+++ b/poetry.lock
@@ -2045,6 +2045,17 @@ files = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+description = "Get CPU info with pure Python"
+optional = false
+python-versions = "*"
+files = [
+    {file = "py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690"},
+    {file = "py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5"},
+]
+
+[[package]]
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
@@ -2108,6 +2119,26 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "pytest-benchmark"
+version = "4.0.0"
+description = "A ``pytest`` fixture for benchmarking code. It will group the tests into rounds that are calibrated to the chosen timer."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-benchmark-4.0.0.tar.gz", hash = "sha256:fb0785b83efe599a6a956361c0691ae1dbb5318018561af10f3e915caa0048d1"},
+    {file = "pytest_benchmark-4.0.0-py3-none-any.whl", hash = "sha256:fdb7db64e31c8b277dff9850d2a2556d8b60bcb0ea6524e36e28ffd7c87f71d6"},
+]
+
+[package.dependencies]
+py-cpuinfo = "*"
+pytest = ">=3.8"
+
+[package.extras]
+aspect = ["aspectlib"]
+elasticsearch = ["elasticsearch"]
+histogram = ["pygal", "pygaljs"]
 
 [[package]]
 name = "pytest-cov"
@@ -3149,4 +3180,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "99eae84bc94082b930d5c3efbe1725be804a34f5d75668e0c6d80fc0a318104e"
+content-hash = "ba4af1a39ae98ba368408ff0083f37ace76ee2649615e8b45d47077f3b0d8de0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "safecheck"
-version = "0.0.2"
+version = "0.0.3"
 description = "Utilities for typechecking, shapechecking and dispatch."
 readme = "README.md"
 authors = ["David Muhr <muhrdavid+github@gmail.com>"]
@@ -47,6 +47,7 @@ plum-dispatch = { version = "^2.2.0" }
 # testing
 pytest = "^7.4.0"
 pytest-html = "^3.2.0"
+pytest-benchmark = "^4.0.0"
 hypothesis = "^6.82.7"
 # coverage
 coverage = "^7.3.0"

--- a/safecheck/__init__.py
+++ b/safecheck/__init__.py
@@ -14,8 +14,8 @@ from beartype import (
 )
 from beartype._data.hint.datahinttyping import BeartypeableT, BeartypeReturn
 from beartype.door import (
-    die_if_unbearable as assert_type,
-    is_bearable as is_type,
+    die_if_unbearable as assert_instance,
+    is_bearable as is_instance,
 )
 from beartype.vale import (
     Is,
@@ -58,9 +58,9 @@ from plum import (
     Kind,
     add_conversion_method,
     add_promotion_rule,
+    conversion_method,
     convert,
     dispatch,
-    overload,  # type: ignore[reportPrivateImportUsage]
     parametric,
     promote,
 )
@@ -70,8 +70,8 @@ __all__ = [
     "typecheck",
     "shapecheck",
     # introspection
-    "is_type",  # like "isinstance(...)"
-    "assert_type",  # like "assert isinstance(...)"
+    "is_instance",  # like "isinstance(...)"
+    "assert_instance",  # like "assert isinstance(...)"
     # validators (runtime only, see https://beartype.readthedocs.io/en/latest/api_vale/)
     "Is",  # Annotated[str, Is[lambda x: x > 0)]]
     "IsAttr",  # Annotated[NumpyArray, IsAttr["ndim", IsEqual[1]]]
@@ -80,10 +80,10 @@ __all__ = [
     "IsInstance",  # Annotated[object, IsInstance[str, bytes]]
     # dispatching
     "dispatch",  # multiple dispatch
-    "overload",  # overload-based dispatch
     "Dispatcher",  # locally-scoped dispatcher
     "convert",  # convert according to given conversion methods
-    "add_conversion_method",  # add new conversion methods
+    "conversion_method",  # decorator for conversion method
+    "add_conversion_method",  # add conversion method
     "promote",  # promote objects to common tpe
     "add_promotion_rule",  # add promotion rules
     "parametric",  # create parametric classes


### PR DESCRIPTION
## Description

Remove ``overload`` from exports, add ``conversion_method`` to exports and rename ``is_type`` to ``is_instance`` and ``assert_type`` to ``assert_instance``.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 🔧 Bug fix
- [ ] 🔐 Security fix
- [ x ] 🚀 Improvement / New feature
- [ ] 📚 Examples / Docs / Tutorials
