### PR TITLE
📌 Drop Python 3.9 support

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,7 +32,7 @@ commands.
 
 We use [micromamba](https://github.com/mamba-org/mamba) to set up a Python environment
 for [poetry](https://python-poetry.org/). Make sure that ``micromamba`` is installed and available. Run
-`task env-create` to create an empty Python 3.9 environment named `safecheck`. After you have successfully created the
+`task env-create` to create an empty Python 3.10 environment named `safecheck`. After you have successfully created the
 conda environment  activate it with `micromamba activate safecheck`. If `poetry` is not already installed, run
 `task poetry-install`. Using the  activated `safecheck` environment check if poetry is using the right environment with
 `poetry env info`. Once the poetry setup is complete, you are ready to install the dependencies.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ imports from ``beartype`` and ``jaxtyping`` if you are using safecheck, e.g. usi
 
 To unify the ``jaxtyping.Array`` interface, we export ``jax.Array as JaxArray`` if
 [Jax](https://github.com/google/jax) is available, ``torch.Tensor as TorchArray`` if
-[PyTorch](https://github.com/pytorch/pytorch) is available and ``numpy.ndarray as NumpyArray`` if
+[PyTorch](https://github.com/pytorch/pytorch) is available and ``numpy.typing.NDArray as NumpyArray`` if
 [NumPy](https://github.com/numpy/numpy) is available.
 
 In addition to the unified ``typecheck``, the library provides a ``typecheck_overload`` decorator.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -60,6 +60,9 @@ tasks:
     typing:
         cmd: poetry run pyright
 
+    typing-quality:
+        cmd: poetry run pyright --ignoreexternal --verifytypes {{.PROJECT}}
+
     safety:
         cmds:
             - poetry run safety check --full-report

--- a/poetry.lock
+++ b/poetry.lock
@@ -917,14 +917,14 @@ files = [
 
 [[package]]
 name = "fsspec"
-version = "2025.2.0"
+version = "2025.3.0"
 description = "File-system specification"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "fsspec-2025.2.0-py3-none-any.whl", hash = "sha256:9de2ad9ce1f85e1931858535bc882543171d197001a0a5eb2ddc04f1781ab95b"},
-    {file = "fsspec-2025.2.0.tar.gz", hash = "sha256:1c24b16eaa0a1798afa0337aa0db9b256718ab2a89c425371f5628d22c3b6afd"},
+    {file = "fsspec-2025.3.0-py3-none-any.whl", hash = "sha256:efb87af3efa9103f94ca91a7f8cb7a4df91af9f74fc106c9c7ea0efd7277c1b3"},
+    {file = "fsspec-2025.3.0.tar.gz", hash = "sha256:a935fd1ea872591f2b5148907d103488fc523295e6c64b835cfad8c3eca44972"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "safecheck"
-version = "0.4.1"
+version = "0.5.0"
 description = "Utilities for typechecking, shapechecking and dispatch."
 readme = "README.md"
 authors = ["David Muhr <muhrdavid+github@gmail.com>"]

--- a/safecheck/__init__.py
+++ b/safecheck/__init__.py
@@ -100,7 +100,9 @@ __all__ = [  # noqa: RUF022
 ]
 
 try:
-    from numpy import ndarray as NumpyArray  # noqa: N812
+    # numpy 1.21.4 is the first version to support Python 3.10, therefore,
+    # we can expect that ``numpy.typing`` and ``NDArray`` is available.
+    from numpy.typing import NDArray as NumpyArray
 
     __all__ += ["NumpyArray"]
 except ImportError:  # pragma: no cover


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
Remove support for Python 3.9 and improve exported NumPy types switching from ``np.ndarray`` to ``np.typing.NDArray``.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 🔧 Bug fix
- [ ] 🔐 Security fix
- [ x ] 🚀 Improvement / New feature
- [ ] 📚 Examples / Docs / Tutorials

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ x ] I've read the [`CONTRIBUTING.md`](https://github.com/davnn/safecheck/blob/main/.github/CONTRIBUTING.md) guide.
- [ x ] I've checked the code using `task check`.
